### PR TITLE
Persist session data in sf-sync folder

### DIFF
--- a/core/audio_clip.py
+++ b/core/audio_clip.py
@@ -1,22 +1,36 @@
 #core\audio_clip.py
 from pydub import AudioSegment
 
+
 class AudioClip:
-    def __init__(self, file_path: str, start_time: float = 0.0, duration: float = None):
+    def __init__(
+        self,
+        file_path: str,
+        start_time: float = 0.0,
+        duration: float = None,
+        trim_start: float = 0.0,
+        trim_end: float = 0.0,
+    ):
         self.file_path = file_path
         self.source_path = file_path
         self.start_time = start_time
         self.audio = AudioSegment.from_file(file_path)
-        self.duration = duration if duration else len(self.audio) / 1000.0  # in seconds
-        self.trim_start = 0.0
-        self.trim_end = len(self.audio) / 1000.0
+        self.trim_start = trim_start
+        self.trim_end = trim_end
+        total_length = len(self.audio) / 1000.0
+        self.duration = (
+            duration if duration is not None else total_length - trim_start - trim_end
+        )
 
     def trim(self, start: float, end: float):
+        total_length = len(self.audio) / 1000.0
         start_ms = int(start * 1000)
         end_ms = int(end * 1000)
         self.audio = self.audio[start_ms:end_ms]
         self.start_time = 0.0
-        self.duration = (end - start)
+        self.trim_start = start
+        self.trim_end = total_length - end
+        self.duration = end - start
 
     def export(self, output_path: str):
         self.audio.export(output_path, format="wav")
@@ -25,9 +39,18 @@ class AudioClip:
         return {
             "file_path": self.file_path,
             "start_time": self.start_time,
-            "duration": self.duration
+            "duration": self.duration,
+            "trim_start": self.trim_start,
+            "trim_end": self.trim_end,
         }
 
     @staticmethod
     def from_dict(data):
-        return AudioClip(data["file_path"], data["start_time"], data["duration"])
+        return AudioClip(
+            data["file_path"],
+            data.get("start_time", 0.0),
+            data.get("duration"),
+            data.get("trim_start", 0.0),
+            data.get("trim_end", 0.0),
+        )
+

--- a/main.py
+++ b/main.py
@@ -195,6 +195,7 @@ class MainWindow(QMainWindow):
                 final = twidget.final_audio
                 if final:
                     final.export(os.path.join(twidget.sync_path, "compiled.wav"), format="wav")
+                    twidget.sync_backend_from_widgets()
                     save_session_to_file(twidget.project_timeline, twidget.sync_path)
 
             export_to_compiled()

--- a/sound-flex-sync/main.py
+++ b/sound-flex-sync/main.py
@@ -16,7 +16,7 @@ from bpy.app.handlers import persistent
 from bpy.props import PointerProperty, BoolProperty, FloatProperty
 from bpy.types import PropertyGroup, Operator, Panel
 
-SYNC_FOLDER = "sf-synch"
+SYNC_FOLDER = "sf-sync"
 
 # Data container for speaker sync info
 class SpeakerAudioData(PropertyGroup):

--- a/storage/session_io.py
+++ b/storage/session_io.py
@@ -39,7 +39,7 @@ def save_session_to_file(timeline: Timeline, speaker_path: str):
                 "file": rel_path.replace('\\', '/'),
                 "start_time": clip.start_time,
                 "trim_start": clip.trim_start,
-                "trim_end": clip.trim_end
+                "trim_end": clip.trim_end,
             }
             track_data["clips"].append(clip_data)
         session_data["tracks"].append(track_data)
@@ -69,7 +69,7 @@ def load_session_from_file(session_path: str) -> Timeline:
                     file_path,
                     start_time=clip_data.get("start_time", 0.0),
                     trim_start=clip_data.get("trim_start", 0.0),
-                    trim_end=clip_data.get("trim_end", None)
+                    trim_end=clip_data.get("trim_end", 0.0),
                 )
                 clip.source_path = file_path
                 track.add_clip(clip)

--- a/ui/clip_widget.py
+++ b/ui/clip_widget.py
@@ -4,15 +4,18 @@ from PyQt6.QtGui import QPainter, QPen, QColor, QMouseEvent, QKeyEvent
 from PyQt6.QtCore import Qt
 import numpy as np
 from pydub import AudioSegment
+from core.audio_clip import AudioClip
+
 
 class ClipWidget(QWidget):
     RESIZE_MARGIN = 10
 
-    def __init__(self, audio_segment: AudioSegment, pixels_per_second=100, parent=None):
+    def __init__(self, clip: AudioClip, pixels_per_second=100, parent=None):
         super().__init__(parent)
-        self.original_audio = audio_segment
-        self.start_time_offset = 0.0
-        self.end_time_offset = 0.0
+        self.backend_clip = clip
+        self.original_audio = AudioSegment.from_file(clip.source_path)
+        self.start_time_offset = clip.trim_start
+        self.end_time_offset = clip.trim_end
         self.pixels_per_second = pixels_per_second
 
         self.selected = False
@@ -31,6 +34,10 @@ class ClipWidget(QWidget):
         self.duration = len(self.audio_clip) / 1000.0
         self.samples = self.extract_samples(self.audio_clip)
         self.setFixedWidth(int(self.duration * self.pixels_per_second))
+        self.backend_clip.audio = self.audio_clip
+        self.backend_clip.trim_start = self.start_time_offset
+        self.backend_clip.trim_end = self.end_time_offset
+        self.backend_clip.duration = self.duration
         self.update()
 
     def extract_samples(self, segment):


### PR DESCRIPTION
## Summary
- store trim offsets and start times on `AudioClip` objects for reliable session serialization
- sync UI clip edits with backend timeline and save sessions into the shared `sf-sync` folder
- correct Blender bridge to use the `sf-sync` directory name

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f3817c10c8327a4b5c196c996f0cc