### PR TITLE
Add timeline ruler using Blender export settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,7 +187,11 @@ class MainWindow(QMainWindow):
                 for _ in range(8):
                     timeline.add_track(Track())
 
-            twidget = TimelineWidget(timeline, sync_path=speaker_data["path"])
+            twidget = TimelineWidget(
+                timeline,
+                sync_path=speaker_data["path"],
+                export_settings=speaker_data.get("export_settings"),
+            )
             self.timeline_widgets[speaker_name] = twidget
 
             def export_to_compiled():

--- a/storage/session_io.py
+++ b/storage/session_io.py
@@ -68,10 +68,12 @@ def load_session_from_file(session_path: str) -> Timeline:
                 clip = AudioClip(
                     file_path,
                     start_time=clip_data.get("start_time", 0.0),
-                    trim_start=clip_data.get("trim_start", 0.0),
-                    trim_end=clip_data.get("trim_end", None)
                 )
                 clip.source_path = file_path
+                clip.trim_start = clip_data.get("trim_start", 0.0)
+                clip.trim_end = clip_data.get("trim_end", clip.duration)
+                if clip.trim_start != 0.0 or clip.trim_end != clip.duration:
+                    clip.trim(clip.trim_start, clip.trim_end)
                 track.add_clip(clip)
             except Exception as e:
                 print(f"[ERROR] Failed to load clip {clip_data['file']}: {e}")

--- a/ui/project_sync.py
+++ b/ui/project_sync.py
@@ -25,6 +25,17 @@ class ProjectSyncManager:
             if os.path.isdir(speaker_path):
                 compiled = os.path.join(speaker_path, "compiled.wav")
                 request = os.path.join(speaker_path, "export_request.json")
+
+                # Attempt to load Blender export settings if present
+                export_settings_path = os.path.join(speaker_path, "export_settings.json")
+                export_settings = None
+                if os.path.exists(export_settings_path):
+                    try:
+                        with open(export_settings_path, "r") as f:
+                            export_settings = json.load(f)
+                    except Exception as e:
+                        print(f"[ERROR] Failed to read {export_settings_path}: {e}")
+
                 self.speakers[name] = {
                     "name": name,
                     "path": speaker_path,
@@ -32,6 +43,7 @@ class ProjectSyncManager:
                     "request_file": request,
                     "needs_export": os.path.exists(request),
                     "has_audio": os.path.exists(compiled),
+                    "export_settings": export_settings,
                 }
 
     def get_speaker_list(self):

--- a/ui/timeline_ruler.py
+++ b/ui/timeline_ruler.py
@@ -13,14 +13,14 @@ class TimelineRuler(QWidget):
         self.frame_start = int(frame_start)
         self.fps = float(fps)
         self.clip_start_seconds = float(clip_start_seconds)
-        self.duration = int(duration)
+        self.duration = float(duration)
 
         self.setFixedHeight(40)
-        self.setMinimumWidth(self.duration * self.pixels_per_second)
+        self.setMinimumWidth(int(self.duration * self.pixels_per_second))
 
     def set_duration(self, duration):
-        self.duration = int(duration)
-        self.setMinimumWidth(self.duration * self.pixels_per_second)
+        self.duration = float(duration)
+        self.setMinimumWidth(int(self.duration * self.pixels_per_second))
         self.update()
 
     def format_time(self, seconds):
@@ -39,9 +39,19 @@ class TimelineRuler(QWidget):
         painter.setPen(pen)
 
         height = self.height()
+
+        total_frames = int(round(self.duration * self.fps))
+        frame_step_pixels = self.pixels_per_second / self.fps if self.fps else 0
+        minor_tick_height = max(6, height // 3)
+
+        if frame_step_pixels:
+            for frame_index in range(total_frames + 1):
+                x = int(round(frame_index * frame_step_pixels))
+                painter.drawLine(x, 0, x, minor_tick_height)
+
         num_seconds = int(self.duration) + 1
         for sec in range(num_seconds):
-            x = sec * self.pixels_per_second
+            x = int(round(sec * self.pixels_per_second))
             painter.drawLine(x, 0, x, height)
 
             frame_number = self.frame_start + int(round((self.clip_start_seconds + sec) * self.fps))

--- a/ui/timeline_ruler.py
+++ b/ui/timeline_ruler.py
@@ -1,0 +1,52 @@
+#ui\\timeline_ruler.py
+from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QPainter, QPen, QColor
+from PyQt6.QtCore import Qt
+
+
+class TimelineRuler(QWidget):
+    """Displays frame numbers and elapsed time along the timeline."""
+
+    def __init__(self, duration, pixels_per_second, frame_start=0, fps=24.0, clip_start_seconds=0.0):
+        super().__init__()
+        self.pixels_per_second = pixels_per_second
+        self.frame_start = int(frame_start)
+        self.fps = float(fps)
+        self.clip_start_seconds = float(clip_start_seconds)
+        self.duration = int(duration)
+
+        self.setFixedHeight(40)
+        self.setMinimumWidth(self.duration * self.pixels_per_second)
+
+    def set_duration(self, duration):
+        self.duration = int(duration)
+        self.setMinimumWidth(self.duration * self.pixels_per_second)
+        self.update()
+
+    def format_time(self, seconds):
+        seconds = int(seconds)
+        h = seconds // 3600
+        m = (seconds % 3600) // 60
+        s = seconds % 60
+        if h > 0:
+            return f"{h:02d}:{m:02d}:{s:02d}"
+        return f"{m:02d}:{s:02d}"
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.fillRect(self.rect(), QColor(245, 245, 245))
+        pen = QPen(Qt.GlobalColor.black)
+        painter.setPen(pen)
+
+        height = self.height()
+        num_seconds = int(self.duration) + 1
+        for sec in range(num_seconds):
+            x = sec * self.pixels_per_second
+            painter.drawLine(x, 0, x, height)
+
+            frame_number = self.frame_start + int(round((self.clip_start_seconds + sec) * self.fps))
+            painter.drawText(x + 2, 12, str(frame_number))
+
+            time_value = self.clip_start_seconds + sec
+            painter.drawText(x + 2, height - 2, self.format_time(time_value))
+

--- a/ui/timeline_ruler.py
+++ b/ui/timeline_ruler.py
@@ -40,15 +40,6 @@ class TimelineRuler(QWidget):
 
         height = self.height()
 
-        total_frames = int(round(self.duration * self.fps))
-        frame_step_pixels = self.pixels_per_second / self.fps if self.fps else 0
-        minor_tick_height = max(6, height // 3)
-
-        if frame_step_pixels:
-            for frame_index in range(total_frames + 1):
-                x = int(round(frame_index * frame_step_pixels))
-                painter.drawLine(x, 0, x, minor_tick_height)
-
         num_seconds = int(self.duration) + 1
         for sec in range(num_seconds):
             x = int(round(sec * self.pixels_per_second))

--- a/ui/timeline_view.py
+++ b/ui/timeline_view.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import (
     QScrollArea
 )
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPainter, QPen, QColor
 from PyQt6.QtWidgets import QPushButton
 from pydub import AudioSegment
 import pygame
@@ -25,14 +26,52 @@ from storage.session_io import load_session_from_file, save_session_to_file
 PIXELS_PER_SECOND = 100
 INITIAL_DURATION = 60  # seconds
 
+class TrackClipArea(QWidget):
+    def __init__(self, duration, pixels_per_second, fps):
+        super().__init__()
+        self.duration = float(duration)
+        self.pixels_per_second = float(pixels_per_second)
+        self.fps = float(fps) if fps else 0.0
+
+        self.setMinimumHeight(80)
+        self.setMinimumWidth(int(self.duration * self.pixels_per_second))
+
+    def set_duration(self, duration):
+        self.duration = float(duration)
+        self.setMinimumWidth(int(self.duration * self.pixels_per_second))
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.fillRect(self.rect(), QColor(238, 238, 238))
+
+        if self.fps <= 0:
+            return
+
+        frame_step_pixels = self.pixels_per_second / self.fps
+        if frame_step_pixels <= 0:
+            return
+
+        total_frames = int(round(self.duration * self.fps)) + 1
+        pen = QPen(QColor(200, 200, 200))
+        pen.setWidth(1)
+        painter.setPen(pen)
+
+        tick_height = 8
+        for frame_index in range(total_frames):
+            x = int(round(frame_index * frame_step_pixels))
+            painter.drawLine(x, 0, x, tick_height)
+
+
 class TrackWidget(QFrame):
-    def __init__(self, track_number, backend_track, notify_duration_change, notify_clip_selected, sync_path):
+    def __init__(self, track_number, backend_track, notify_duration_change, notify_clip_selected, sync_path, fps, timeline_duration):
         super().__init__()
         self.sync_path = sync_path
         self.track_number = track_number
         self.backend_track = backend_track
         self.notify_duration_change = notify_duration_change
         self.notify_clip_selected = notify_clip_selected
+        self.fps = fps
 
         self.setAcceptDrops(True)
         self.setFrameShape(QFrame.Shape.Box)
@@ -45,9 +84,7 @@ class TrackWidget(QFrame):
         self.track_layout = QVBoxLayout()
         self.track_layout.addWidget(self.label)
 
-        self.clip_area = QWidget()
-        self.clip_area.setMinimumHeight(80)
-        self.clip_area.setStyleSheet("background-color: #eee;")
+        self.clip_area = TrackClipArea(timeline_duration, PIXELS_PER_SECOND, self.fps)
         self.clip_area.setLayout(QVBoxLayout())
         self.clip_area.layout().setContentsMargins(0, 0, 0, 0)
 
@@ -55,6 +92,10 @@ class TrackWidget(QFrame):
         self.setLayout(self.track_layout)
 
         self.current_x = 0
+
+
+    def set_timeline_duration(self, duration):
+        self.clip_area.set_duration(duration)
 
 
     def dragEnterEvent(self, event):
@@ -157,6 +198,8 @@ class TimelineWidget(QWidget):
                 notify_duration_change=self.extend_if_needed,
                 notify_clip_selected=self.on_clip_selected,
                 sync_path=self.sync_path,
+                fps=self.fps,
+                timeline_duration=self.duration,
             )
             self.track_widgets.append(track_widget)
             self.layout.addWidget(track_widget)
@@ -227,6 +270,8 @@ class TimelineWidget(QWidget):
             self.duration = required_duration
             self.timeline_area.setMinimumWidth(self.duration * PIXELS_PER_SECOND)
             self.ruler.set_duration(self.duration)
+            for track_widget in self.track_widgets:
+                track_widget.set_timeline_duration(self.duration)
 
     def on_clip_selected(self, clip_widget):
         self.selected_clip = clip_widget

--- a/ui/timeline_view.py
+++ b/ui/timeline_view.py
@@ -119,10 +119,15 @@ class TimelineWidget(QWidget):
         # === Timeline metadata from Blender ===
         scene_data = self.export_settings.get("scene", {})
         sound_data = self.export_settings.get("sound", {})
-        self.frame_start = int(scene_data.get("frame_start", 0))
-        self.fps = float(scene_data.get("fps", 24.0))
-        self.clip_start = float(sound_data.get("clip_start_seconds", 0.0))
-        clip_end = float(sound_data.get("clip_end_seconds", INITIAL_DURATION))
+        self.frame_start = int(scene_data.get("frame_start") or 0)
+        self.fps = float(scene_data.get("fps") or 24.0)
+        self.clip_start = float(sound_data.get("clip_start_seconds") or 0.0)
+        clip_end_raw = sound_data.get("clip_end_seconds")
+        clip_end = (
+            float(clip_end_raw)
+            if isinstance(clip_end_raw, (int, float))
+            else self.clip_start + INITIAL_DURATION
+        )
         duration_from_export = clip_end - self.clip_start
         if 0 < duration_from_export < 3600:
             self.duration = int(duration_from_export)

--- a/ui/timeline_view.py
+++ b/ui/timeline_view.py
@@ -17,6 +17,7 @@ from core.track import Track
 from ui.clip_widget import ClipWidget
 from ui.properties_panel import PropertiesPanel
 from ui.playhead import Playhead
+from ui.timeline_ruler import TimelineRuler
 from storage.session_io import load_session_from_file, save_session_to_file
 
 
@@ -108,12 +109,25 @@ class TrackWidget(QFrame):
 
 
 class TimelineWidget(QWidget):
-    def __init__(self, project_timeline, sync_path=None): 
+    def __init__(self, project_timeline, sync_path=None, export_settings=None):
         super().__init__()
         self.project_timeline = project_timeline
         self.final_audio = None
-        self.duration = INITIAL_DURATION
         self.sync_path = sync_path
+        self.export_settings = export_settings or {}
+
+        # === Timeline metadata from Blender ===
+        scene_data = self.export_settings.get("scene", {})
+        sound_data = self.export_settings.get("sound", {})
+        self.frame_start = int(scene_data.get("frame_start", 0))
+        self.fps = float(scene_data.get("fps", 24.0))
+        self.clip_start = float(sound_data.get("clip_start_seconds", 0.0))
+        clip_end = float(sound_data.get("clip_end_seconds", INITIAL_DURATION))
+        duration_from_export = clip_end - self.clip_start
+        if 0 < duration_from_export < 3600:
+            self.duration = int(duration_from_export)
+        else:
+            self.duration = INITIAL_DURATION
 
         # === Tracks ===
         self.track_widgets = []
@@ -121,13 +135,23 @@ class TimelineWidget(QWidget):
         self.layout.setSpacing(10)
         self.layout.setContentsMargins(10, 10, 10, 10)
 
+        # Ruler at top of timeline
+        self.ruler = TimelineRuler(
+            self.duration,
+            PIXELS_PER_SECOND,
+            frame_start=self.frame_start,
+            fps=self.fps,
+            clip_start_seconds=self.clip_start,
+        )
+        self.layout.addWidget(self.ruler)
+
         for i, track in enumerate(self.project_timeline.tracks):
             track_widget = TrackWidget(
                 i + 1,
                 track,
                 notify_duration_change=self.extend_if_needed,
                 notify_clip_selected=self.on_clip_selected,
-                sync_path=self.sync_path
+                sync_path=self.sync_path,
             )
             self.track_widgets.append(track_widget)
             self.layout.addWidget(track_widget)
@@ -197,6 +221,7 @@ class TimelineWidget(QWidget):
         if required_duration > self.duration:
             self.duration = required_duration
             self.timeline_area.setMinimumWidth(self.duration * PIXELS_PER_SECOND)
+            self.ruler.set_duration(self.duration)
 
     def on_clip_selected(self, clip_widget):
         self.selected_clip = clip_widget


### PR DESCRIPTION
## Summary
- load Blender `export_settings.json` for each speaker
- display a dual-frame/time ruler on the timeline using the export metadata
- pass export settings to timeline widgets and sync the ruler when duration changes

## Testing
- `python -m py_compile ui/timeline_ruler.py ui/timeline_view.py ui/project_sync.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5a1acc9c483279143219d8f9e0cd1