### PR TITLE
Add keyboard shortcuts for clip offset and position adjustments

### DIFF
--- a/ui/clip_widget.py
+++ b/ui/clip_widget.py
@@ -22,7 +22,7 @@ class ClipWidget(QWidget):
         self.update_audio_clip()
         self.setMinimumHeight(80)
 
-        self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
 
     def update_audio_clip(self, notify=True):
@@ -81,6 +81,9 @@ class ClipWidget(QWidget):
             painter.fillRect(self.width() - self.RESIZE_MARGIN, 0, self.RESIZE_MARGIN, self.height(), QColor(180, 180, 180))
 
     def mousePressEvent(self, event: QMouseEvent):
+        if event.button() != Qt.MouseButton.LeftButton:
+            return super().mousePressEvent(event)
+
         if event.pos().x() <= self.RESIZE_MARGIN:
             self.selected_side = 'left'
         elif event.pos().x() >= self.width() - self.RESIZE_MARGIN:
@@ -88,13 +91,20 @@ class ClipWidget(QWidget):
         else:
             self.selected_side = None
 
-        if self.selected:
-            self.selected = False
-            self.clearFocus()
-        else:
+        if not self.selected:
             self.selected = True
-            self.setFocus()
 
+        self.setFocus()
+        self.update()
+        event.accept()
+
+    def deselect(self):
+        if not self.selected:
+            return
+
+        self.selected = False
+        self.selected_side = None
+        self.clearFocus()
         self.update()
 
     def _step_from_modifiers(self, modifiers: Qt.KeyboardModifier) -> float:

--- a/ui/clip_widget.py
+++ b/ui/clip_widget.py
@@ -8,12 +8,13 @@ from pydub import AudioSegment
 class ClipWidget(QWidget):
     RESIZE_MARGIN = 10
 
-    def __init__(self, audio_segment: AudioSegment, pixels_per_second=100, parent=None):
+    def __init__(self, audio_segment: AudioSegment, pixels_per_second=100, parent=None, on_properties_changed=None):
         super().__init__(parent)
         self.original_audio = audio_segment
         self.start_time_offset = 0.0
         self.end_time_offset = 0.0
         self.pixels_per_second = pixels_per_second
+        self.on_properties_changed = on_properties_changed
 
         self.selected = False
         self.selected_side = None  # 'left', 'right', or None
@@ -24,7 +25,7 @@ class ClipWidget(QWidget):
         self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
 
 
-    def update_audio_clip(self):
+    def update_audio_clip(self, notify=True):
         start_ms = int(self.start_time_offset * 1000)
         end_ms = len(self.original_audio) - int(self.end_time_offset * 1000)
         self.audio_clip = self.original_audio[start_ms:end_ms]
@@ -32,6 +33,8 @@ class ClipWidget(QWidget):
         self.samples = self.extract_samples(self.audio_clip)
         self.setFixedWidth(int(self.duration * self.pixels_per_second))
         self.update()
+        if notify:
+            self._emit_properties_changed()
 
     def extract_samples(self, segment):
         samples = np.array(segment.get_array_of_samples())
@@ -94,35 +97,76 @@ class ClipWidget(QWidget):
 
         self.update()
 
+    def _step_from_modifiers(self, modifiers: Qt.KeyboardModifier) -> float:
+        if modifiers & Qt.KeyboardModifier.ControlModifier:
+            return 0.01
+        if modifiers & Qt.KeyboardModifier.ShiftModifier:
+            return 1.0
+        return 0.1
+
+    def _max_start_offset(self) -> float:
+        total_duration = len(self.original_audio) / 1000.0
+        return max(0.0, total_duration - self.end_time_offset - 0.001)
+
+    def _max_end_offset(self) -> float:
+        total_duration = len(self.original_audio) / 1000.0
+        return max(0.0, total_duration - self.start_time_offset - 0.001)
+
+    def _move_clip(self, delta_seconds: float):
+        delta_pixels = int(round(delta_seconds * self.pixels_per_second))
+        if delta_pixels == 0:
+            return
+
+        new_x = self.x() + delta_pixels
+        max_x = max(0, (self.parent().width() - self.width()) if self.parent() else 0)
+        new_x = max(0, min(new_x, max_x))
+        if new_x != self.x():
+            self.move(new_x, self.y())
+            self._emit_properties_changed()
+
+    def _emit_properties_changed(self):
+        if callable(self.on_properties_changed):
+            self.on_properties_changed(self)
+
     def keyPressEvent(self, event: QKeyEvent):
         if not self.selected:
             return
 
-        if self.selected_side is None:
-            return
-
-        # How much to trim
-        small_step = 0.1
-        large_step = 1.0
-        step = large_step if event.modifiers() == Qt.KeyboardModifier.ShiftModifier else small_step
+        step = self._step_from_modifiers(event.modifiers())
+        handled = False
 
         if self.selected_side == 'left':
             if event.key() == Qt.Key.Key_Left:
-                self.start_time_offset += step
+                self.start_time_offset = min(self._max_start_offset(), self.start_time_offset + step)
                 self.update_audio_clip()
+                handled = True
             elif event.key() == Qt.Key.Key_Right:
                 if self.start_time_offset - step >= 0:
-                    self.start_time_offset -= step
+                    self.start_time_offset = max(0.0, self.start_time_offset - step)
                     self.update_audio_clip()
+                    handled = True
 
-        if self.selected_side == 'right':
+        elif self.selected_side == 'right':
             if event.key() == Qt.Key.Key_Left:
                 if self.end_time_offset - step >= 0:
-                    self.end_time_offset -= step
+                    self.end_time_offset = max(0.0, self.end_time_offset - step)
                     self.update_audio_clip()
+                    handled = True
             elif event.key() == Qt.Key.Key_Right:
-                self.end_time_offset += step
+                self.end_time_offset = min(self._max_end_offset(), self.end_time_offset + step)
                 self.update_audio_clip()
+                handled = True
+
+        else:
+            if event.key() == Qt.Key.Key_Left:
+                self._move_clip(-step)
+                handled = True
+            elif event.key() == Qt.Key.Key_Right:
+                self._move_clip(step)
+                handled = True
+
+        if handled:
+            event.accept()
 
     def get_properties(self):
         return {

--- a/ui/timeline_view.py
+++ b/ui/timeline_view.py
@@ -285,6 +285,9 @@ class TimelineWidget(QWidget):
                 track_widget.set_timeline_duration(self.duration)
 
     def on_clip_selected(self, clip_widget):
+        if hasattr(self, 'selected_clip') and self.selected_clip is not clip_widget:
+            self.selected_clip.deselect()
+
         self.selected_clip = clip_widget
         props = clip_widget.get_properties()
         self.properties_panel.update_fields(props)

--- a/ui/timeline_view.py
+++ b/ui/timeline_view.py
@@ -64,13 +64,14 @@ class TrackClipArea(QWidget):
 
 
 class TrackWidget(QFrame):
-    def __init__(self, track_number, backend_track, notify_duration_change, notify_clip_selected, sync_path, fps, timeline_duration):
+    def __init__(self, track_number, backend_track, notify_duration_change, notify_clip_selected, notify_clip_updated, sync_path, fps, timeline_duration):
         super().__init__()
         self.sync_path = sync_path
         self.track_number = track_number
         self.backend_track = backend_track
         self.notify_duration_change = notify_duration_change
         self.notify_clip_selected = notify_clip_selected
+        self.notify_clip_updated = notify_clip_updated
         self.fps = fps
 
         self.setAcceptDrops(True)
@@ -127,7 +128,12 @@ class TrackWidget(QFrame):
                     clip.source_path = asset_path  # make sure AudioClip supports this
                     self.backend_track.add_clip(clip)
 
-                    clip_widget = ClipWidget(clip.audio, pixels_per_second=PIXELS_PER_SECOND, parent=self.clip_area)
+                    clip_widget = ClipWidget(
+                        clip.audio,
+                        pixels_per_second=PIXELS_PER_SECOND,
+                        parent=self.clip_area,
+                        on_properties_changed=self.handle_clip_properties_changed,
+                    )
                     clip_widget.move(self.current_x, 0)
                     clip_widget.show()
 
@@ -147,6 +153,10 @@ class TrackWidget(QFrame):
                 self.notify_clip_selected(clip_widget)
             ClipWidget.mousePressEvent(clip_widget, event)
         return handler
+
+    def handle_clip_properties_changed(self, clip_widget):
+        if callable(self.notify_clip_updated):
+            self.notify_clip_updated(clip_widget)
 
 
 class TimelineWidget(QWidget):
@@ -197,6 +207,7 @@ class TimelineWidget(QWidget):
                 track,
                 notify_duration_change=self.extend_if_needed,
                 notify_clip_selected=self.on_clip_selected,
+                notify_clip_updated=self.on_clip_properties_changed,
                 sync_path=self.sync_path,
                 fps=self.fps,
                 timeline_duration=self.duration,
@@ -303,6 +314,11 @@ class TimelineWidget(QWidget):
         # Refresh property panel to reflect true values after update
         props = self.selected_clip.get_properties()
         self.properties_panel.update_fields(props)
+
+    def on_clip_properties_changed(self, clip_widget):
+        if hasattr(self, 'selected_clip') and self.selected_clip is clip_widget:
+            props = clip_widget.get_properties()
+            self.properties_panel.update_fields(props)
 
     def start_playback(self):
         if self.playing:


### PR DESCRIPTION
## Summary
- add keyboard controls for clip start/end offsets and timeline position using arrow keys with modifier-based increments
- propagate clip property change notifications so the properties panel stays in sync with keyboard adjustments

## Testing
- python -m compileall ui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131f0e43fc8327a0f8628a4306a26c)